### PR TITLE
Add RangeAnswer with any number of alternatives

### DIFF
--- a/src/answer.js
+++ b/src/answer.js
@@ -61,34 +61,39 @@ export class PriorityAnswer {
   }
 }
 
-// prettier-ignore
-const RANGE_SCORING = {
-  5: {
-    '00': 16, '10':  8, '20':  0, '30':  0, '40':  0,
-    '01': 12, '11': 12, '21':  4, '31':  4, '41':  4,
-    '02':  8, '12':  8, '22':  8, '32':  8, '42':  8,
-    '03':  4, '13':  4, '23':  4, '33': 12, '43': 12,
-    '04':  0, '14':  0, '24':  0, '34':  8, '44': 16,
-  }
+function rangeScoring(me, you, N) {
+  function maskWeight(me, N) {
+    let fromMiddle = me - Math.ceil(N / 2);
+
+    if (fromMiddle < 0 || N % 2 == 1)
+      fromMiddle++;
+
+    return Math.ceil(N / 2) - Math.abs(fromMiddle) - 1;
+  };
+
+  const rawScore = (N - Math.abs(me - you) - 1) * (N - 1);
+  const mask = maskWeight(me, N) * (N - 1);
+
+  return rawScore - mask;
 };
 
 export class RangeAnswer {
   constructor(selectedIndex, alternativesCount, { isImportant = false } = {}) {
     this.selectedIndex = selectedIndex;
     this.alternativesCount = alternativesCount;
-    this.scoring = RANGE_SCORING[this.alternativesCount];
-    if (!this.scoring) {
-      throw new Error(
-        `Range questions with ${
-          this.alternativesCount
-        } alternatives are not supported.`
-      );
-    }
-    this.maxScore = this.scoring[`${selectedIndex}${selectedIndex}`];
+	if (this.alternativesCount <= 1) {
+		throw new Error(
+		  `Range questions with ${
+			this.alternativesCount
+		  } alternatives are not supported.`
+		);
+	  }
+    this.scoring = rangeScoring;
+    this.maxScore = this.scoring(selectedIndex, selectedIndex, this.alternativesCount);
     this.isImportant = isImportant;
   }
 
   match(other) {
-    return this.scoring[`${this.selectedIndex}${other.selectedIndex}`];
+    return this.scoring(this.selectedIndex, other.selectedIndex, this.alternativesCount);
   }
 }

--- a/src/match.test.js
+++ b/src/match.test.js
@@ -66,6 +66,8 @@ describe('match', () => {
     expectMatch('0/5', '4/5', 0.0);
     expectMatch('2/5', '_', 0.0);
     expect(parseMatch('3/5', '4/5')).toBeGreaterThan(parseMatch('2/5', '4/5'));
+    expectMatch('3/6', '3/6', 100.0);
+    expect(parseMatch('3/6', '4/6')).toBeGreaterThan(parseMatch('2/6', '4/6'));
   });
 
   test('important on everything is the same as important on nothing', () => {


### PR DESCRIPTION
I wanted to take a shot at the RangeAnswer only being available for 5 alternatives. Even though there probably isn't a huge demand for another amount - it could be useful.

I'm not sure how the score weight were chosen but I did my best to find a pattern.

Here's how I calculate the score. **r** is the raw score, this is simply the distance between the choices `me` and `you` in increments of `N - 1`, where `N` is the number of alternatives. **m** is a mask that ensures that timid choices doesn't weigh as much as more intense choices, ie choices further from the middle. The mask multiplied by `N - 1`, subtracted from the raw scores leaves **s** - the final score.

The exact same technique is used to calculate the score for situations with more alternatives. For example `N = 6` as shown below. The only difference is that there are two middles, so the mask for these are the same. According to Likert you probably don't want to use even numbers, but this just shows that you can.

```
N = 5           |     N = 6
     r m  s     |          r m  s
00: 16 0 16     |     00: 25 0 25
01: 12 0 12     |     01: 20 0 20
02:  8 0  8     |     02: 15 0 15
03:  4 0  4     |     03: 10 0 10
04:  0 0  0     |     04:  5 0  5
                |     05:  0 0  0
10: 12 1  8                
11: 16 1 12     |     10: 20 1 15
12: 12 1  8     |     11: 25 1 20
13:  8 1  4     |     12: 20 1 15
14:  4 1  0     |     13: 15 1 10
                |     14: 10 1  5
20:  8 2  0     |     15:  5 1  0
21: 12 2  4                
22: 16 2  8     |     20: 15 2  5
23: 12 2  4     |     21: 20 2 10
24:  8 2  0     |     22: 25 2 15
                |     23: 20 2 10
30:  4 1  0     |     24: 15 2  5
31:  8 1  4     |     25: 10 2  0
32: 12 1  8                
33: 16 1 12     |     30: 10 2  0
34: 12 1  8     |     31: 15 2  5
                |     32: 20 2 10
40:  0 0  0     |     33: 25 2 15
41:  4 0  4     |     34: 20 2 10
42:  8 0  8     |     35: 15 2  5
43: 12 0 12                
44: 16 0 16     |     40:  5 1  0
                |     41: 10 1  5
                |     42: 15 1 10
                |     43: 20 1 15
                |     44: 25 1 20
                |     45: 20 1 15
                        
                |     50:  0 0  0
                |     51:  5 0  5
                |     52: 10 0 10
                |     53: 15 0 15
                |     54: 20 0 20
```
In the demonstration `N = 5` yields the same results as https://github.com/svt/election-compass-match/blob/ddf37c806a2adf2a8559e28b69d370a2ef59b5d4/src/answer.js#L65-L73